### PR TITLE
Exercises 3.19.-3.20.

### DIFF
--- a/part2/phonebook/src/App.js
+++ b/part2/phonebook/src/App.js
@@ -68,8 +68,11 @@ const App = () => {
           })
           .catch(error => {
             setErrorMessage(
-              `The note '${foundPerson.name}' was already deleted from server`
+              `${error.response.data.error}`
             )
+            setTimeout(() => {
+              setErrorMessage(null)
+            }, 3000)
             setPersons(persons.filter(n => n.id !== foundPerson.id))
           })
         }
@@ -81,6 +84,14 @@ const App = () => {
           setMessage(`Added '${newName}' `)
           setTimeout(() => {
             setMessage(null)
+          }, 3000)
+        })
+        .catch(error => {
+          setErrorMessage(
+            `${error.response.data.error}`
+          )
+          setTimeout(() => {
+            setErrorMessage(null)
           }, 3000)
         })
       }

--- a/part3/index.js
+++ b/part3/index.js
@@ -31,7 +31,7 @@ app.get('/api/persons', (req, res) => {
   })
 })
 
-app.post('/api/persons', (req, res) => {
+app.post('/api/persons', (req, res, next) => {
   const body = req.body
 
   if (!body.name ||  !body.number) {
@@ -54,6 +54,7 @@ app.post('/api/persons', (req, res) => {
   person.save().then(savedPerson => {
     res.json(savedPerson)
   })
+  .catch(error => next(error))
 })
 
 app.get('/info', (req, res) => {
@@ -109,6 +110,8 @@ const errorHandler = (error, req, res, next) => {
 
   if (error.name === 'CastError' && error.kind == 'ObjectId') {
     return res.status(400).send({ error: 'malformatted id' })
+  } else if (error.name === 'ValidationError') {
+    return res.status(400).json({ error: error.message })
   }
 
   next(error)

--- a/part3/index.js
+++ b/part3/index.js
@@ -4,6 +4,7 @@ const app = express()
 const morgan = require('morgan')
 const cors = require('cors')
 const Person = require('./models/person')
+const { query } = require('express')
 
 const PORT = process.env.PORT
 
@@ -75,7 +76,7 @@ app.put('/api/persons/:id', (req, res, next) => {
     number: body.number,
   }
 
-  Person.findByIdAndUpdate(req.params.id, person, { new: true })
+  Person.findByIdAndUpdate(req.params.id, person, { new: true, runValidators: true, context: 'query' })
     .then(updatedPerson => {
       res.json(updatedPerson)
     })

--- a/part3/index.js
+++ b/part3/index.js
@@ -19,12 +19,6 @@ app.use(express.static('build'))
 
 app.use(cors())
 
-// const generateId = () => {
-//   const id  = Math.random() * (10000 - persons.length) + persons.length
-
-//   return Math.floor(id)
-// }
-
 app.get('/api/persons', (req, res) => {
   Person.find({}).then(persons => {
     res.json(persons)
@@ -39,22 +33,19 @@ app.post('/api/persons', (req, res, next) => {
       error: 'name and/or number missing'
     })
   }
-  // TO DO else if to get all people inside the database and check
-  // } else if (persons.find(person => person.name === body.name)) {
-  //   return res.status(400).json({
-  //     error: "Name must be unique"
-  //   })
-  // }
 
   const person = new Person({
     name: req.body.name,
     number: req.body.number,
   })
 
-  person.save().then(savedPerson => {
-    res.json(savedPerson)
-  })
-  .catch(error => next(error))
+  person
+    .save()
+    .then(savedPerson => savedPerson.toJSON())
+    .then(savedAndFormattedPerson => {
+      res.json(savedAndFormattedPerson)
+    })
+    .catch(error => next(error))
 })
 
 app.get('/info', (req, res) => {

--- a/part3/models/person.js
+++ b/part3/models/person.js
@@ -18,8 +18,8 @@ mongoose.connect(url, { useNewUrlParser: true, useUnifiedTopology: true })
   })
 
 const personSchema = new mongoose.Schema({
-  name: { type: String, required: true, unique: true },
-  number: { type: String, required: true },
+  name: { type: String, required: true, minlength: 3, unique: true },
+  number: { type: String, required: true, minlength: 8 },
 })
 
 personSchema.plugin(uniqueValidator);

--- a/part3/models/person.js
+++ b/part3/models/person.js
@@ -1,6 +1,9 @@
 const mongoose = require('mongoose')
+const uniqueValidator = require('mongoose-unique-validator');
 
 mongoose.set('useFindAndModify', false)
+mongoose.set('useCreateIndex', true);
+
 
 const url = process.env.MONGODB_URI
 
@@ -15,9 +18,11 @@ mongoose.connect(url, { useNewUrlParser: true, useUnifiedTopology: true })
   })
 
 const personSchema = new mongoose.Schema({
-  name: String,
-  number: String,
+  name: { type: String, required: true, unique: true },
+  number: { type: String, required: true },
 })
+
+personSchema.plugin(uniqueValidator);
 
 personSchema.set('toJSON', {
   transform: (document, returnedObject) => {

--- a/part3/package-lock.json
+++ b/part3/package-lock.json
@@ -794,6 +794,16 @@
         "package-json": "^6.3.0"
       }
     },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -919,6 +929,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "mongoose-unique-validator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mongoose-unique-validator/-/mongoose-unique-validator-2.0.3.tgz",
+      "integrity": "sha512-3/8pmvAC1acBZS6eWKAWQUiZBlARE1wyWtjga4iQ2wDJeOfRlIKmAvTNHSZXKaAf7RCRUd7wh7as6yWAOrjpQg==",
+      "requires": {
+        "lodash.foreach": "^4.1.0",
+        "lodash.get": "^4.0.2"
+      }
     },
     "morgan": {
       "version": "1.10.0",

--- a/part3/package.json
+++ b/part3/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "mongoose": "^5.9.18",
+    "mongoose-unique-validator": "^2.0.3",
     "morgan": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION

3.19: Phonebook database, step7
Add validation to your phonebook application, that will make sure that a newly added person has a unique name. Our current frontend won't allow users to try and create duplicates, but we can attempt to create them directly with Postman or the VS Code REST client.

Mongoose does not offer a built-in validator for this purpose. Install the mongoose-unique-validator package with npm and use it instead.

If an HTTP POST request tries to add a name that is already in the phonebook, the server must respond with an appropriate status code and error message.


(node:49251) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
connected to MongoDB
Read the mongoose documentation to find out how to get rid of the warning.

3.20*: Phonebook database, step8
Expand the validation so that the name stored in the database has to be at least three characters long, and the phone number must have at least 8 digits.

Expand the frontend so that it displays some form of error message when a validation error occurs. Err