### PR TITLE
4.20*: bloglist expansion, step8 4.21*: bloglist expansion, step9

### DIFF
--- a/part4/app.js
+++ b/part4/app.js
@@ -24,6 +24,7 @@ app.use(cors())
 app.use(express.static('build'))
 app.use(express.json())
 app.use(middleware.requestLogger)
+app.use(middleware.tokenExtractor)
 
 app.use('/api/blogs', blogsRouter)
 app.use('/api/users', usersRouter)

--- a/part4/controllers/blog.js
+++ b/part4/controllers/blog.js
@@ -66,8 +66,23 @@ blogsRouter.put('/:id', (request, response, next) => {
 
 blogsRouter.delete('/:id', async (request, response) => {
 
-  await Blog.findByIdAndRemove(request.params.id)
-  response.status(204).end()
+  const decodedToken = jwt.verify(request.token, process.env.SECRET)
+
+  if (!request.token || !decodedToken.id) {
+    return response.status(401).json({ error: 'token missong or invalid' })
+  }
+  const user = await User.findById(decodedToken.id)
+
+  if (user.blogs.includes(request.params.id)) {
+    await Blog.findByIdAndRemove(request.params.id)
+    response
+      .status(204)
+      .end()
+  } else {
+    response
+      .status(403)
+      .end()
+  }
 })
 
 module.exports = blogsRouter

--- a/part4/controllers/blog.js
+++ b/part4/controllers/blog.js
@@ -3,14 +3,6 @@ const Blog = require('../models/blog')
 const User = require('../models/user')
 const jwt = require('jsonwebtoken')
 
-const getTokenFrom = request => {
-  const authorization = request.get('authorization')
-  if (authorization && authorization.toLowerCase().startsWith('bearer ')) {
-    return authorization.substring(7)
-  }
-  return null
-}
-
 blogsRouter.get('/', async (request, response) => {
 
   const blogs = await Blog
@@ -22,11 +14,9 @@ blogsRouter.post('/', async (request, response) => {
 
   const body = request.body
 
-  const token = getTokenFrom(request)
+  const decodedToken = jwt.verify(request.token, process.env.SECRET)
 
-  const decodedToken = jwt.verify(token, process.env.SECRET)
-
-  if (!token || !decodedToken.id) {
+  if (!request.token || !decodedToken.id) {
     return response.status(401).json({ error: 'token missong or invalid' })
   }
   const user = await User.findById(decodedToken.id)

--- a/part4/requests/createblog.rest
+++ b/part4/requests/createblog.rest
@@ -1,0 +1,11 @@
+post http://localhost:3003/api/blogs
+Content-Type: application/json
+Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlZGwiLCJpZCI6IjVlZmQzMjhjNjdiMmFkOTY3ZmNiNTU1MSIsImlhdCI6MTU5NDAwMDYzMX0.Us12DjBeMYomXVMly2jsY3H2MdwuRkQSQej_EeUUAP0
+
+{
+  "title": "Token authentication for newbies",
+  "author": "Autor desconhecido",
+  "url": "refactor.com",
+  "likes": 12,
+  "userId": "5efd328c67b2ad967fcb5551"
+}

--- a/part4/requests/deleteBlog.rest
+++ b/part4/requests/deleteBlog.rest
@@ -1,0 +1,2 @@
+delete http://localhost:3003/api/blogs/5f03ceddb670cb9f61c83796
+Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlZGwiLCJpZCI6IjVlZmQzMjhjNjdiMmFkOTY3ZmNiNTU1MSIsImlhdCI6MTU5NDA4ODM1NH0.9VqK-baUg8KB2j2qeydZdnI2TiZD7m8N8CcZSmfYp-w

--- a/part4/requests/getAllBlogs.rest
+++ b/part4/requests/getAllBlogs.rest
@@ -1,0 +1,2 @@
+get http://localhost:3003/api/blogs
+Content-Type: application/json

--- a/part4/requests/getAllUsers.rest
+++ b/part4/requests/getAllUsers.rest
@@ -1,0 +1,2 @@
+get http://localhost:3003/api/users
+Content-Type: application/json

--- a/part4/requests/getBlogById.rest
+++ b/part4/requests/getBlogById.rest
@@ -1,0 +1,2 @@
+get http://localhost:3003/api/blogs/5f03ceddb670cb9f61c83796
+Content-Type: application/json

--- a/part4/requests/userLogin.rest
+++ b/part4/requests/userLogin.rest
@@ -1,0 +1,7 @@
+post http://localhost:3003/api/login
+Content-Type: application/json
+
+{
+    "username": "tedl",
+    "password": "google5"
+}

--- a/part4/utils/middleware.js
+++ b/part4/utils/middleware.js
@@ -12,14 +12,30 @@ const unknownEndpoint = (request, response) => {
   response.status(404).send({ error: 'unknown endpoint' })
 }
 
+const tokenExtractor = (request, response, next) => {
+  const authorization = request.get('authorization')
+  if (authorization && authorization.toLowerCase().startsWith('bearer ')) {
+    request.token = authorization.substring(7)
+  }
+  next()
+}
+
 const errorHandler = (error, request, response, next) => {
 
   logger.error(error.message)
 
-  if (error.name === 'CastError' && error.kind === 'ObjectId') {
-    return response.status(400).send({ error: 'malformatted id' })
+  if (error.name === 'CastError') {
+    return response.status(400).send({
+      error: 'malformatted id'
+    })
   } else if (error.name === 'ValidationError') {
-    return response.status(400).json({ error: error.message })
+    return response.status(400).json({
+      error: error.message
+    })
+  } else if (error.name === 'JsonWebTokenError') {
+    return response.status(401).json({
+      error: 'invalid token'
+    })
   }
 
   next(error)
@@ -28,5 +44,6 @@ const errorHandler = (error, request, response, next) => {
 module.exports = {
   requestLogger,
   unknownEndpoint,
+  tokenExtractor,
   errorHandler
 }


### PR DESCRIPTION
This example from part 4 shows taking the token from the header with the getTokenFrom helper function.

If you used the same solution, refactor taking the token to a middleware. The middleware should take the token from the Authorization header and place it to the token field of the request object.

In other words, if you register this middleware in the app.js file before all routes 
routes can access the token with request.token:
Remember that a normal middleware is a function with three parameters, that at the end calls the last parameter next in order to move the control to next middleware:


Change the delete blog operation so that a blog can be deleted only by the user who added the blog. Therefore, deleting a blog is possible only if the token sent with the request is the same as that of the blog's creator.

If deleting a blog is attempted without a token or by a wrong user, the operation should return a suitable status code.